### PR TITLE
Support for arrays of univariate distributions

### DIFF
--- a/src/DifferentiableExpectations.jl
+++ b/src/DifferentiableExpectations.jl
@@ -20,7 +20,7 @@ using ChainRulesCore:
     rrule_via_ad,
     unthunk
 using DensityInterface: logdensityof
-using Distributions: Distribution, MvNormal, Normal
+using Distributions: Distribution, MvNormal, Normal, UnivariateDistribution
 using DocStringExtensions
 using LinearAlgebra: Diagonal, cholesky, dot
 using OhMyThreads: tmap, treduce, tmapreduce

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -34,6 +34,16 @@ The resulting object `dist` needs to satisfy:
 """
 abstract type DifferentiableExpectation{threaded} end
 
+function _sample(
+    dist_array::AbstractArray{<:UnivariateDistribution}, rng::AbstractRNG, nb_samples::Int
+)
+    return [map(d -> rand(rng, d), dist_array) for _ in 1:nb_samples]
+end
+
+function _sample(dist, rng::AbstractRNG, nb_samples::Int)
+    return rand(rng, dist, nb_samples)
+end
+
 """
     presamples(F::DifferentiableExpectation, θ...)
 
@@ -43,7 +53,7 @@ function presamples(F::DifferentiableExpectation, θ...)
     (; dist_constructor, rng, nb_samples, seed) = F
     dist = dist_constructor(θ...)
     isnothing(seed) || seed!(rng, seed)
-    xs = maybe_eachcol(rand(rng, dist, nb_samples))
+    xs = maybe_eachcol(_sample(dist, rng, nb_samples))
     return xs
 end
 

--- a/src/reinforce.jl
+++ b/src/reinforce.jl
@@ -84,6 +84,14 @@ function Reinforce(
     )
 end
 
+function _logdensity(dist::Array{<:UnivariateDistribution}, x)
+    return sum(logdensityof(d, xi) for (d, xi) in zip(dist, x))
+end
+
+function _logdensity(dist, x)
+    return logdensityof(dist, x)
+end
+
 function dist_logdensity_grad(
     rc::RuleConfig, F::Reinforce{threaded}, x, θ...
 ) where {threaded}
@@ -91,7 +99,7 @@ function dist_logdensity_grad(
     if !isnothing(dist_logdensity_grad)
         dθ = dist_logdensity_grad(x, θ...)
     else
-        _logdensity_partial(_θ...) = logdensityof(dist_constructor(_θ...), x)
+        _logdensity_partial(_θ...) = _logdensity(dist_constructor(_θ...), x)
         l, pullback = rrule_via_ad(rc, _logdensity_partial, θ...)
         dθ = Base.tail(pullback(one(l)))
     end


### PR DESCRIPTION
With these changes, the following works and gives the same results:

```julia
using DifferentiableExpectations
using Distributions
using Zygote
using LinearAlgebra
using Random

f(x) = x
d(θ) = [Normal(t, 1.0) for t in θ]
d2(θ) = MvNormal(θ, I)

r = Reinforce(f, d; seed=0, nb_samples=1, rng=MersenneTwister(0)) # seed is buggy with default rng, to investigate
r2 = Reinforce(f, d2; seed=0, nb_samples=1, rng=MersenneTwister(0))

θ = randn(10)
r(θ)
r2(θ)

jacobian(r, θ)[1] .== jacobian(r2, θ)[1]
```
Downside: jacobian computation for r is slower (about 8 times on my laptop) than r2, and allocates more. Why? Because we allocate a vector of Normal each time dist_constructor is called?
Can we do better?
Is it also the case in InferOpt where we do things more similar to r than r2?

TODO:
- [ ] add proper tests
- [ ] check that Reparametrize also works with it
- [ ] check that it works with matrices

---
Edit on performance:
- r
```bash
BenchmarkTools.Trial: 4276 samples with 1 evaluation.
 Range (min … max):  1.056 ms … 64.596 ms  ┊ GC (min … max): 0.00% … 97.12%
 Time  (median):     1.117 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.166 ms ±  1.034 ms  ┊ GC (mean ± σ):  3.12% ±  5.29%

          ▁▄▇▆██▆▅▆▄▃▁                                        
  ▁▁▂▂▂▃▄▆████████████▇█▇▅▅▅▅▄▆▆▅▆▆▆▅▃▄▃▃▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁ ▃
  1.06 ms        Histogram: frequency by time        1.27 ms <

 Memory estimate: 293.87 KiB, allocs estimate: 6876.
```
- r2
```bash
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):   97.094 μs … 377.408 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     111.322 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   113.841 μs ±  13.580 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

          █ ▁▂▆▆▄                                                
  ▁▁▁▁▁▁▂▅████████▅▄▄▄▃▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  97.1 μs          Histogram: frequency by time          164 μs <

 Memory estimate: 27.95 KiB, allocs estimate: 644.
```
- InferOpt
```bash
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  44.389 μs … 141.895 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     51.330 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   51.740 μs ±   4.336 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

          ▂▄ ▁ ▂▄▇█▆▄▂                                          
  ▁▁▁▁▂▂▄▄██▇█████████▇▅▄▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  44.4 μs         Histogram: frequency by time         70.9 μs <

 Memory estimate: 18.18 KiB, allocs estimate: 416.
```

InferOpt seems faster than r2