### PR TITLE
Improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -16,6 +17,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 ChainRulesCore = "1.23"
+Compat = "3,4"
 DensityInterface = "0.4"
 Distributions = "0.25"
 DocStringExtensions = "0.9"

--- a/docs/src/background.md
+++ b/docs/src/background.md
@@ -13,7 +13,26 @@ See the book by [blondelElementsDifferentiableProgramming2024](@citet) to know m
 
 Most of the math below is taken from [mohamedMonteCarloGradient2020](@citet).
 
+## Empirical distribution
+
+Implemented by [`FixedAtomsProbabilityDistribution`](@ref).
+
+### Mean
+
+An empirical distribution ``\pi`` is given by a set of atoms ``a_i`` and associated weights ``w_i \geq 0`` such that ``\sum_i w_i = 1``.
+Its expectation is ``\mathbb{E}[\pi] = \sum w_i a_i``.
+The gradient of this expectation with respect to weight ``w_j`` is ``\partial_{w_j} \mathbb{E}[\pi] = a_j``.
+Thus, the vector-Jacobian product is:
+
+```math
+\left(\partial_{w_j} \mathbb{E}[\pi]\right)^\top v = a_j^\top v 
+```
+
+We assume the atoms are kept constant during differentiation.
+
 ## REINFORCE
+
+Implemented by [`Reinforce`](@ref).
 
 ### Principle
 
@@ -62,6 +81,8 @@ This gives the following vector-Jacobian product:
 ```
 
 ## Reparametrization
+
+Implemented by [`Reparametrization`](@ref).
 
 ### Trick
 

--- a/src/DifferentiableExpectations.jl
+++ b/src/DifferentiableExpectations.jl
@@ -29,10 +29,10 @@ using Statistics: Statistics, cov, mean, std
 using StatsBase: StatsBase
 
 include("utils.jl")
+include("distribution.jl")
 include("abstract.jl")
 include("reinforce.jl")
 include("reparametrization.jl")
-include("distribution.jl")
 
 export DifferentiableExpectation
 export Reinforce

--- a/src/DifferentiableExpectations.jl
+++ b/src/DifferentiableExpectations.jl
@@ -19,6 +19,7 @@ using ChainRulesCore:
     rrule,
     rrule_via_ad,
     unthunk
+using Compat: @compat
 using DensityInterface: logdensityof
 using Distributions: Distribution, MvNormal, Normal
 using DocStringExtensions
@@ -38,5 +39,8 @@ export DifferentiableExpectation
 export Reinforce
 export Reparametrization
 export FixedAtomsProbabilityDistribution
+export empirical_distribution
+
+@compat public atoms, weights
 
 end # module DifferentiableExpectations

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -34,6 +34,15 @@ The resulting object `dist` needs to satisfy:
 """
 abstract type DifferentiableExpectation{threaded} end
 
+tmap_or_map(::DifferentiableExpectation{true}, args...) = tmap(args...)
+tmap_or_map(::DifferentiableExpectation{false}, args...) = map(args...)
+
+tmapreduce_or_mapreduce(::DifferentiableExpectation{true}, args...) = tmapreduce(args...)
+tmapreduce_or_mapreduce(::DifferentiableExpectation{false}, args...) = mapreduce(args...)
+
+tmean_or_mean(::DifferentiableExpectation{true}, args...) = tmean(args...)
+tmean_or_mean(::DifferentiableExpectation{false}, args...) = mean(args...)
+
 """
     presamples(F::DifferentiableExpectation, θ...)
 
@@ -62,19 +71,11 @@ function samples_from_presamples(
 ) where {threaded}
     (; f) = F
     fk = FixKwargs(f, kwargs)
-    if threaded
-        return tmap(fk, xs)
-    else
-        return map(fk, xs)
-    end
+    return tmap_or_map(F, fk, xs)
 end
 
 function (F::DifferentiableExpectation{threaded})(θ...; kwargs...) where {threaded}
     ys = samples(F, θ...; kwargs...)
-    y = if threaded
-        tmean(ys)
-    else
-        mean(ys)
-    end
+    y = tmean_or_mean(F, ys)
     return y
 end

--- a/src/abstract.jl
+++ b/src/abstract.jl
@@ -1,7 +1,7 @@
 """
-    DifferentiableExpectation{threaded}
+    DifferentiableExpectation{t}
 
-Abstract supertype for differentiable parametric expectations `F : θ -> 𝔼[f(X)]` where `X ∼ p(θ)`, whose value and derivative are approximated with Monte-Carlo averages.
+Abstract supertype for differentiable parametric expectations `E : θ -> 𝔼[f(X)]` where `X ∼ p(θ)`, whose value and derivative are approximated with Monte-Carlo averages.
 
 # Subtypes
 
@@ -10,9 +10,9 @@ Abstract supertype for differentiable parametric expectations `F : θ -> 𝔼[f(
 
 # Calling behavior
 
-    (F::DifferentiableExpectation)(θ...; kwargs...)
+    (E::DifferentiableExpectation)(θ...; kwargs...)
 
-Return a Monte-Carlo average `(1/s) ∑f(xᵢ)` where the `xᵢ ∼ p(θ)` are iid samples.
+Return a Monte-Carlo average `(1/S) ∑f(xᵢ)` where the `xᵢ ∼ p(θ)` are iid samples.
 
 # Type parameters
 
@@ -32,50 +32,37 @@ The resulting object `dist` needs to satisfy:
   - the [Random API](https://docs.julialang.org/en/v1/stdlib/Random/#Hooking-into-the-Random-API) for sampling with `rand(rng, dist)`
   - the [DensityInterface.jl API](https://github.com/JuliaMath/DensityInterface.jl) for loglikelihoods with `logdensityof(dist, x)`
 """
-abstract type DifferentiableExpectation{threaded} end
+abstract type DifferentiableExpectation{t} end
 
-tmap_or_map(::DifferentiableExpectation{true}, args...) = tmap(args...)
-tmap_or_map(::DifferentiableExpectation{false}, args...) = map(args...)
-
-tmapreduce_or_mapreduce(::DifferentiableExpectation{true}, args...) = tmapreduce(args...)
-tmapreduce_or_mapreduce(::DifferentiableExpectation{false}, args...) = mapreduce(args...)
-
-tmean_or_mean(::DifferentiableExpectation{true}, args...) = tmean(args...)
-tmean_or_mean(::DifferentiableExpectation{false}, args...) = mean(args...)
+is_threaded(::DifferentiableExpectation{t}) where {t} = Val(t)
 
 """
-    presamples(F::DifferentiableExpectation, θ...)
+    empirical_predistribution(E::DifferentiableExpectation, θ...)
 
-Return a vector `[x₁, ..., xₛ]` or matrix `[x₁ ... xₛ]` where the `xᵢ ∼ p(θ)` are iid samples.
+Return a uniform [`FixedAtomsProbabilityDistribution`](@ref) over `{x₁, ..., xₛ}`, where the `xᵢ ∼ p(θ)` are iid samples.
 """
-function presamples(F::DifferentiableExpectation, θ...)
-    (; dist_constructor, rng, nb_samples, seed) = F
+function empirical_predistribution(E::DifferentiableExpectation, θ...)
+    (; dist_constructor, rng, nb_samples, seed) = E
     dist = dist_constructor(θ...)
     isnothing(seed) || seed!(rng, seed)
     xs = maybe_eachcol(rand(rng, dist, nb_samples))
-    return xs
+    xdist = FixedAtomsProbabilityDistribution(xs; threaded=unval(is_threaded(E)))
+    return xdist
 end
 
 """
-    samples(F::DifferentiableExpectation, θ...; kwargs...)
+    empirical_distribution(E::DifferentiableExpectation, θ...; kwargs...)
 
-Return a vector `[f(x₁), ..., f(xₛ)]` where the `xᵢ ∼ p(θ)` are iid samples.
+Return a uniform [`FixedAtomsProbabilityDistribution`](@ref) over `{f(x₁), ..., f(xₛ)}`, where the `xᵢ ∼ p(θ)` are iid samples.
 """
-function samples(F::DifferentiableExpectation{threaded}, θ...; kwargs...) where {threaded}
-    xs = presamples(F, θ...)
-    return samples_from_presamples(F, xs; kwargs...)
+function empirical_distribution(E::DifferentiableExpectation, θ...; kwargs...)
+    xdist = empirical_predistribution(E, θ...)
+    fk = FixKwargs(E.f, kwargs)
+    ydist = map(fk, xdist)
+    return ydist
 end
 
-function samples_from_presamples(
-    F::DifferentiableExpectation{threaded}, xs::AbstractVector; kwargs...
-) where {threaded}
-    (; f) = F
-    fk = FixKwargs(f, kwargs)
-    return tmap_or_map(F, fk, xs)
-end
-
-function (F::DifferentiableExpectation{threaded})(θ...; kwargs...) where {threaded}
-    ys = samples(F, θ...; kwargs...)
-    y = tmean_or_mean(F, ys)
-    return y
+function (E::DifferentiableExpectation)(θ...; kwargs...)
+    ydist = empirical_distribution(E, θ...; kwargs...)
+    return mean(ydist)
 end

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -13,7 +13,7 @@ julia> using DifferentiableExpectations, Statistics, Zygote
 julia> dist = FixedAtomsProbabilityDistribution([2, 3], [0.4, 0.6]);
 
 julia> map(abs2, dist)
-FixedAtomsProbabilityDistribution{false}([4, 9], [0.4, 0.6])
+FixedAtomsProbabilityDistribution{false, Int64, Float64}([4, 9], [0.4, 0.6])
 
 julia> mean(abs2, dist)
 7.0
@@ -52,12 +52,19 @@ struct FixedAtomsProbabilityDistribution{threaded,A,W<:Real}
     end
 end
 
-function Base.show(
-    io::IO, dist::FixedAtomsProbabilityDistribution{threaded}
-) where {threaded}
-    (; atoms, weights) = dist
-    return print(io, "FixedAtomsProbabilityDistribution{$threaded}($atoms, $weights)")
+tmap_or_map(::FixedAtomsProbabilityDistribution{true}, args...) = tmap(args...)
+tmap_or_map(::FixedAtomsProbabilityDistribution{false}, args...) = map(args...)
+
+function tmapreduce_or_mapreduce(::FixedAtomsProbabilityDistribution{true}, args...)
+    return tmapreduce(args...)
 end
+
+function tmapreduce_or_mapreduce(::FixedAtomsProbabilityDistribution{false}, args...)
+    return mapreduce(args...)
+end
+
+tmean_or_mean(::FixedAtomsProbabilityDistribution{true}, args...) = tmean(args...)
+tmean_or_mean(::FixedAtomsProbabilityDistribution{false}, args...) = mean(args...)
 
 Base.length(dist::FixedAtomsProbabilityDistribution) = length(dist.atoms)
 
@@ -78,11 +85,7 @@ Apply `f` to the atoms of `dist`, leave the weights unchanged.
 """
 function Base.map(f, dist::FixedAtomsProbabilityDistribution{threaded}) where {threaded}
     (; atoms, weights) = dist
-    new_atoms = if threaded
-        tmap(f, atoms)
-    else
-        map(f, atoms)
-    end
+    new_atoms = tmap_or_map(dist, f, atoms)
     return FixedAtomsProbabilityDistribution(new_atoms, weights)
 end
 
@@ -93,11 +96,7 @@ Compute the expectation of `dist`, i.e. the sum of all atoms multiplied by their
 """
 function Statistics.mean(dist::FixedAtomsProbabilityDistribution{threaded}) where {threaded}
     (; atoms, weights) = dist
-    if threaded
-        return tmapreduce(*, +, weights, atoms)
-    else
-        return mapreduce(*, +, weights, atoms)
-    end
+    return tmapreduce_or_mapreduce(dist, *, +, weights, atoms)
 end
 
 """
@@ -109,40 +108,27 @@ function Statistics.mean(f, dist::FixedAtomsProbabilityDistribution)
     return mean(map(f, dist))
 end
 
-function ChainRulesCore.rrule(
-    ::typeof(mean), f, dist::FixedAtomsProbabilityDistribution{threaded}
-) where {threaded}
-    (; atoms, weights) = dist
-    new_atoms = if threaded
-        tmap(f, atoms)
-    else
-        map(f, atoms)
+function ChainRulesCore.rrule(::typeof(mean), dist::FixedAtomsProbabilityDistribution)
+    (; atoms) = dist
+    e = mean(dist)
+    function dist_mean_pullback(Δe)
+        Δatoms = NoTangent()
+        Δweights = tmap_or_map(dist, Base.Fix1(dot, Δe), atoms)
+        Δdist = Tangent{FixedAtomsProbabilityDistribution}(; atoms=Δatoms, weights=Δweights)
+        return NoTangent(), Δdist
     end
-
-    function expectation_pullback(de)
-        d_atoms = NoTangent()
-        d_weights = if threaded
-            tmap(Base.Fix1(dot, de), new_atoms)
-        else
-            map(Base.Fix1(dot, de), new_atoms)
-        end
-        d_dist = Tangent{FixedAtomsProbabilityDistribution}(;
-            atoms=d_atoms, weights=d_weights
-        )
-        return NoTangent(), NoTangent(), d_dist
-    end
-
-    e = mean(FixedAtomsProbabilityDistribution(new_atoms, weights))
-    return e, expectation_pullback
+    return e, dist_mean_pullback
 end
 
-function ChainRulesCore.rrule(
-    ::typeof(mean), dist::FixedAtomsProbabilityDistribution{threaded}
-) where {threaded}
-    e, pb = rrule(mean, identity, dist)
-    function pb_nof(de)
-        p = pb(de)
-        return p[1], p[3]
+function ChainRulesCore.rrule(::typeof(mean), f, dist::FixedAtomsProbabilityDistribution)
+    new_dist = map(f, dist)
+    new_atoms = new_dist.atoms
+    e = mean(new_dist)
+    function dist_fmean_pullback(Δe)
+        Δatoms = NoTangent()
+        Δweights = tmap_or_map(dist, Base.Fix1(dot, Δe), new_atoms)
+        Δdist = Tangent{FixedAtomsProbabilityDistribution}(; atoms=Δatoms, weights=Δweights)
+        return NoTangent(), NoTangent(), Δdist
     end
-    return e, pb_nof
+    return e, dist_fmean_pullback
 end

--- a/src/distribution.jl
+++ b/src/distribution.jl
@@ -124,7 +124,8 @@ end
 function ChainRulesCore.rrule(::typeof(mean), dist::FixedAtomsProbabilityDistribution)
     (; atoms) = dist
     e = mean(dist)
-    function dist_mean_pullback(Δe)
+    function dist_mean_pullback(Δe_thunked)
+        Δe = unthunk(Δe_thunked)
         Δatoms = NoTangent()
         Δweights = mymap(is_threaded(dist), Base.Fix1(dot, Δe), atoms)
         Δdist = Tangent{FixedAtomsProbabilityDistribution}(; atoms=Δatoms, weights=Δweights)
@@ -137,7 +138,8 @@ function ChainRulesCore.rrule(::typeof(mean), f, dist::FixedAtomsProbabilityDist
     new_dist = map(f, dist)
     new_atoms = new_dist.atoms
     e = mean(new_dist)
-    function dist_fmean_pullback(Δe)
+    function dist_fmean_pullback(Δe_thunked)
+        Δe = unthunk(Δe_thunked)
         Δatoms = NoTangent()
         Δweights = mymap(is_threaded(dist), Base.Fix1(dot, Δe), new_atoms)
         Δdist = Tangent{FixedAtomsProbabilityDistribution}(; atoms=Δatoms, weights=Δweights)

--- a/src/reinforce.jl
+++ b/src/reinforce.jl
@@ -15,7 +15,7 @@ E = Reinforce(exp, Normal; nb_samples=10^5)
 E_true(μ, σ) = mean(LogNormal(μ, σ))
 
 μ, σ = 0.5, 1,0
-∇E, ∇E_true = gradient(F, μ, σ), gradient(E_true, μ, σ)
+∇E, ∇E_true = gradient(E, μ, σ), gradient(E_true, μ, σ)
 isapprox(collect(∇E), collect(∇E_true); rtol=1e-1)
 
 # output

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,8 @@
+"""
+    FixKwargs(f, kwargs)
+
+Callable struct that fixes the keyword arguments of `f` to `kwargs...`, and only accepts positional arguments.
+"""
 struct FixKwargs{F,K}
     f::F
     kwargs::K
@@ -11,5 +16,39 @@ function tmean(args...)
     return treduce(+, args...) / length(first(args))
 end
 
+"""
+    maybe_eachcol(x::AbstractVector)
+
+Return `x`.
+"""
 maybe_eachcol(x::AbstractVector) = x
+
+"""
+    maybe_eachcol(x::AbstractMatrix)
+
+Return `eachcol(x)`.
+"""
 maybe_eachcol(x::AbstractMatrix) = eachcol(x)
+
+uniform_weights(x::AbstractArray) = ones(size(x)) ./ prod(size(x))
+
+"""
+    tmap_or_map(::SomeType{threaded}, args...)
+
+Apply either `tmap(args...)` or `map(args...)` depending on the value of `threaded`.
+"""
+function tmap_or_map end
+
+"""
+    tmapreduce_or_mapreduce(::SomeType{threaded}, args...)
+
+Apply either `tmapreduce(args...)` or `mapreduce(args...)` depending on the value of `threaded`.
+"""
+function tmapreduce_or_mapreduce end
+
+"""
+    tmean_or_mean(::SomeType{threaded}, args...)
+
+Apply either `tmean(args...)` or `mean(args...)` depending on the value of `threaded`.
+"""
+function tmean_or_mean end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,13 +8,9 @@ struct FixKwargs{F,K}
     kwargs::K
 end
 
-function (fk::FixKwargs)(args...)
-    return fk.f(args...; fk.kwargs...)
-end
+(fk::FixKwargs)(args...) = fk.f(args...; fk.kwargs...)
 
-function tmean(args...)
-    return treduce(+, args...) / length(first(args))
-end
+tmean(args...) = treduce(+, args...) / length(first(args))
 
 """
     maybe_eachcol(x::AbstractVector)
@@ -33,22 +29,27 @@ maybe_eachcol(x::AbstractMatrix) = eachcol(x)
 uniform_weights(x::AbstractArray) = ones(size(x)) ./ prod(size(x))
 
 """
-    tmap_or_map(::SomeType{threaded}, args...)
+    mymap(::Val{threaded}, args...)
 
 Apply either `tmap(args...)` or `map(args...)` depending on the value of `threaded`.
 """
-function tmap_or_map end
+mymap(::Val{true}, args...) = tmap(args...)
+mymap(::Val{false}, args...) = map(args...)
 
 """
-    tmapreduce_or_mapreduce(::SomeType{threaded}, args...)
+    mymapreduce(::Val{threaded}, args...)
 
 Apply either `tmapreduce(args...)` or `mapreduce(args...)` depending on the value of `threaded`.
 """
-function tmapreduce_or_mapreduce end
+mymapreduce(::Val{true}, args...) = tmapreduce(args...)
+mymapreduce(::Val{false}, args...) = mapreduce(args...)
 
 """
-    tmean_or_mean(::SomeType{threaded}, args...)
+    tmean_or_mean(::Val{threaded}, args...)
 
 Apply either `tmean(args...)` or `mean(args...)` depending on the value of `threaded`.
 """
-function tmean_or_mean end
+mymean(::Val{true}, args...) = tmean(args...)
+mymean(::Val{false}, args...) = mean(args...)
+
+unval(::Val{t}) where {t} = t

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,8 +10,6 @@ end
 
 (fk::FixKwargs)(args...) = fk.f(args...; fk.kwargs...)
 
-tmean(args...) = treduce(+, args...) / length(first(args))
-
 """
     maybe_eachcol(x::AbstractVector)
 
@@ -43,13 +41,5 @@ Apply either `tmapreduce(args...)` or `mapreduce(args...)` depending on the valu
 """
 mymapreduce(::Val{true}, args...) = tmapreduce(args...)
 mymapreduce(::Val{false}, args...) = mapreduce(args...)
-
-"""
-    tmean_or_mean(::Val{threaded}, args...)
-
-Apply either `tmean(args...)` or `mean(args...)` depending on the value of `threaded`.
-"""
-mymean(::Val{true}, args...) = tmean(args...)
-mymean(::Val{false}, args...) = mean(args...)
 
 unval(::Val{t}) where {t} = t


### PR DESCRIPTION
**Source**

- Rename `F` into `E` everywhere (for Expectation)
- Make `FixedAtomsProbabilityDistribution` in `Reinforce` and `Reparametrization`
- Define `empirical_distribution` and its `Reinforce` reverse rule
- Define `atoms` and `weights`
- Remove conditionals for threaded vs. non-threaded by defining the trait-based `mymap` and `mymapreduce`

**Doc**

- Revamp the background page with shorter formulas.
- Add a section on differentiating through probability distributions.
- Add more docstrings.

**Tests**

- Add test that the rrule for `Reinforce` gives exactly the same result as the composition of the rrules for `empirical_distribution` followed by `mean`